### PR TITLE
Auth consistency

### DIFF
--- a/src/lib/calendarEvent.ts
+++ b/src/lib/calendarEvent.ts
@@ -16,7 +16,7 @@ export type CalendarEventPartialSchema = typeof calendarEventPartialSchema;
 export class CalendarEventRepo {
   constructor(private readonly prisma: PrismaClient) {}
 
-  async getOneAndValidateOwner(id: number, ownerId: string) {
+  async getOne(id: number) {
     const e = await this.prisma.calendarEvent.findUnique({
       where: {
         id: Number(id),
@@ -25,10 +25,15 @@ export class CalendarEventRepo {
     if (e == null) {
       throw new APIError('NOT_FOUND', 'Resource not found');
     }
-    if (e.ownerId != ownerId) {
+    return e;
+  }
+
+  async getOneAndValidateOwner(id: number, ownerId: string) {
+    const calendarEvent = await this.getOne(id);
+    if (calendarEvent.ownerId != ownerId) {
       throw new APIError('INVALID_PERMISSIONS', 'You do not have permission to edit this object.');
     }
-    return e;
+    return calendarEvent;
   }
 
   async new(data: z.infer<CalendarEventSchema>, ownerId: string) {
@@ -51,10 +56,6 @@ export class CalendarEventRepo {
         dateStart: 'desc',
       },
     });
-  }
-
-  async getOne(id: number, ownerId: string) {
-    return this.getOneAndValidateOwner(id, ownerId);
   }
 
   async update(data: z.infer<CalendarEventPartialSchema>, id: number, ownerId: string) {

--- a/src/lib/exerciseEvent.ts
+++ b/src/lib/exerciseEvent.ts
@@ -22,7 +22,7 @@ export type ExerciseEventSchema = typeof exerciseEventSchema;
 export class ExerciseEventRepo {
   constructor(private readonly prisma: PrismaClient) {}
 
-  async getOneAndValidateOwner(id: number, ownerId: string) {
+  async getOne(id: number) {
     const exerciseEvent = await this.prisma.exerciseEvent.findUnique({
       where: {
         id: Number(id),
@@ -31,6 +31,11 @@ export class ExerciseEventRepo {
     if (exerciseEvent == null) {
       throw new APIError('NOT_FOUND', 'Resource not found');
     }
+    return exerciseEvent;
+  }
+
+  async getOneAndValidateOwner(id: number, ownerId: string) {
+    const exerciseEvent = await this.getOne(id);
     if (exerciseEvent.ownerId != ownerId) {
       throw new APIError('INVALID_PERMISSIONS', 'You do not have permission to edit this object.');
     }
@@ -95,10 +100,6 @@ export class ExerciseEventRepo {
         exercise: true,
       },
     });
-  }
-
-  async getOne(id: number, ownerId: string) {
-    return this.getOneAndValidateOwner(id, ownerId);
   }
 
   async getOneThatNeedsExerciseMigration() {

--- a/src/lib/journalEntry.ts
+++ b/src/lib/journalEntry.ts
@@ -76,12 +76,16 @@ export class JournalEntryRepo {
     })) as JournalEntry[];
   }
 
-  async getOne(id: number, ownerId: string) {
-    const journalEntry = await this.prisma.journalEntry.findUnique({
+  async getOne(id: number) {
+    return await this.prisma.journalEntry.findUnique({
       where: {
         id,
       },
     });
+  }
+
+  async getOneAndValidateOwner(id: number, ownerId: string) {
+    const journalEntry = await this.getOne(id);
     if (journalEntry == null) {
       throw new APIError('NOT_FOUND', 'Resource not found');
     }

--- a/src/lib/journalEntry.ts
+++ b/src/lib/journalEntry.ts
@@ -77,18 +77,19 @@ export class JournalEntryRepo {
   }
 
   async getOne(id: number) {
-    return await this.prisma.journalEntry.findUnique({
+    const journalEntry = await this.prisma.journalEntry.findUnique({
       where: {
         id,
       },
     });
+    if (journalEntry == null) {
+      throw new APIError('NOT_FOUND', 'Resource not found');
+    }
+    return journalEntry;
   }
 
   async getOneAndValidateOwner(id: number, ownerId: string) {
     const journalEntry = await this.getOne(id);
-    if (journalEntry == null) {
-      throw new APIError('NOT_FOUND', 'Resource not found');
-    }
     if (journalEntry.ownerId != ownerId) {
       throw new APIError('INVALID_PERMISSIONS', 'You do not have permission to edit this object.');
     }

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -12,7 +12,7 @@ export class ProfileRepo {
   constructor(private readonly prisma: PrismaClient) {}
 
   async getOne(ownerId: string) {
-    return await this.prisma.profile.findUnique({
+    const profile = await this.prisma.profile.findUnique({
       where: {
         ownerId: ownerId,
       },
@@ -55,13 +55,14 @@ export class ProfileRepo {
         },
       },
     });
+    if (profile == null) {
+      throw new APIError('NOT_FOUND', 'Resource not found');
+    }
+    return profile;
   }
 
   async getOneAndValidateOwner(ownerId: string) {
     const profile = await this.getOne(ownerId);
-    if (profile == null) {
-      throw new APIError('NOT_FOUND', 'Resource not found');
-    }
     if (profile.ownerId != ownerId) {
       throw new APIError('INVALID_PERMISSIONS', 'You do not have permission to edit this object.');
     }

--- a/src/lib/profile.ts
+++ b/src/lib/profile.ts
@@ -11,9 +11,8 @@ export type ProfileSchema = typeof profileSchema;
 export class ProfileRepo {
   constructor(private readonly prisma: PrismaClient) {}
 
-  async getOneAndValidateOwner(ownerId: string) {
-    // Fetch
-    const profile = await this.prisma.profile.findUnique({
+  async getOne(ownerId: string) {
+    return await this.prisma.profile.findUnique({
       where: {
         ownerId: ownerId,
       },
@@ -56,6 +55,10 @@ export class ProfileRepo {
         },
       },
     });
+  }
+
+  async getOneAndValidateOwner(ownerId: string) {
+    const profile = await this.getOne(ownerId);
     if (profile == null) {
       throw new APIError('NOT_FOUND', 'Resource not found');
     }
@@ -63,10 +66,6 @@ export class ProfileRepo {
       throw new APIError('INVALID_PERMISSIONS', 'You do not have permission to edit this object.');
     }
     return profile;
-  }
-
-  async getOne(ownerId: string) {
-    return this.getOneAndValidateOwner(ownerId);
   }
 
   async update(data: z.infer<ProfileSchema>, ownerId: string) {

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -52,7 +52,7 @@ export class ProjectRepo {
   constructor(private readonly prisma: PrismaClient) {}
 
   async getOne(id: string) {
-    return await this.prisma.project.findUnique({
+    const project = await this.prisma.project.findUnique({
       where: {
         id: id,
       },
@@ -64,13 +64,14 @@ export class ProjectRepo {
         },
       },
     });
+    if (project == null) {
+      throw new APIError('NOT_FOUND', 'Resource not found');
+    }
+    return project;
   }
 
   async getOneAndValidateOwner(id: string, ownerId: string) {
     const project = await this.getOne(id);
-    if (project == null) {
-      throw new APIError('NOT_FOUND', 'Resource not found');
-    }
     if (project.ownerId != ownerId) {
       throw new APIError('INVALID_PERMISSIONS', 'You do not have permission to edit this object.');
     }

--- a/src/lib/project.ts
+++ b/src/lib/project.ts
@@ -51,8 +51,8 @@ export type ProjectSessionSchema = typeof projectSessionSchema;
 export class ProjectRepo {
   constructor(private readonly prisma: PrismaClient) {}
 
-  async getOneAndValidateOwner(id: string, ownerId: string) {
-    const project = await this.prisma.project.findUnique({
+  async getOne(id: string) {
+    return await this.prisma.project.findUnique({
       where: {
         id: id,
       },
@@ -64,6 +64,10 @@ export class ProjectRepo {
         },
       },
     });
+  }
+
+  async getOneAndValidateOwner(id: string, ownerId: string) {
+    const project = await this.getOne(id);
     if (project == null) {
       throw new APIError('NOT_FOUND', 'Resource not found');
     }
@@ -100,10 +104,6 @@ export class ProjectRepo {
         },
       },
     });
-  }
-
-  async getOne(id: string, ownerId: string) {
-    return this.getOneAndValidateOwner(id, ownerId);
   }
 
   async update(data: z.infer<ProjectPartialSchema>, id: string, ownerId: string) {

--- a/src/lib/trainingProgram.ts
+++ b/src/lib/trainingProgram.ts
@@ -87,9 +87,6 @@ export class TrainingProgramRepo {
 
   async getOneAndValidateOwner(id: number, ownerId: string) {
     const trainingProgram = await this.getOne(id);
-    if (trainingProgram == null) {
-      throw new APIError('NOT_FOUND', 'Resource not found');
-    }
     if (trainingProgram.ownerId != ownerId) {
       throw new APIError('INVALID_PERMISSIONS', 'You do not have permission to view this object.');
     }

--- a/src/routes/dashboard/+page.server.ts
+++ b/src/routes/dashboard/+page.server.ts
@@ -36,25 +36,22 @@ export const load: PageServerLoad = async ({ locals }) => {
     const journalEntries = await journalEntryRepo.get(user?.userId);
     const calendarEvents = await calendarEventRepo.get(user?.userId);
 
-    const widgets = await widgetRepo.get({
-      where: { ownerId: user?.userId, isTemplate: false },
-      include: {
-        owner: true,
-        trainingProgram: {
-          include: {
-            days: {
-              include: {
-                exercises: {
-                  include: {
-                    exercise: true,
-                  },
+    const widgets = await widgetRepo.getAllDashboardWidgetsForUser(user.userId, {
+      owner: true,
+      trainingProgram: {
+        include: {
+          days: {
+            include: {
+              exercises: {
+                include: {
+                  exercise: true,
                 },
-                exerciseGroups: {
-                  include: {
-                    exercises: {
-                      include: {
-                        exercise: true,
-                      },
+              },
+              exerciseGroups: {
+                include: {
+                  exercises: {
+                    include: {
+                      exercise: true,
                     },
                   },
                 },
@@ -62,17 +59,17 @@ export const load: PageServerLoad = async ({ locals }) => {
             },
           },
         },
-        datasets: {
-          include: {
-            customQueries: {
-              include: {
-                conditions: true,
-              },
+      },
+      datasets: {
+        include: {
+          customQueries: {
+            include: {
+              conditions: true,
             },
           },
-          orderBy: {
-            name: 'asc',
-          },
+        },
+        orderBy: {
+          name: 'asc',
         },
       },
     });

--- a/src/routes/journalEntry/[id]/edit/+page.server.ts
+++ b/src/routes/journalEntry/[id]/edit/+page.server.ts
@@ -11,9 +11,11 @@ export const load: PageServerLoad = async ({ locals, params }) => {
   const id = Number(params.id);
 
   const repo = new JournalEntryRepo(prisma);
-  let journalEntry: JournalEntry;
   try {
-    journalEntry = await repo.getOne(id, user?.userId);
+    const journalEntry = await repo.getOneAndValidateOwner(id, user?.userId);
+    return {
+      journalEntry,
+    };
   } catch (e) {
     if (e instanceof APIError) {
       throw error(404, { message: 'Not found' });
@@ -21,8 +23,4 @@ export const load: PageServerLoad = async ({ locals, params }) => {
     console.error(e);
     throw error(500, { message: SERVER_ERROR });
   }
-
-  return {
-    journalEntry,
-  };
 };

--- a/src/routes/profile/edit/+page.server.ts
+++ b/src/routes/profile/edit/+page.server.ts
@@ -10,9 +10,11 @@ export const load: PageServerLoad = async ({ locals }) => {
   const { user } = await locals.auth.validateUser();
 
   const repo = new ProfileRepo(prisma);
-  let profile: Profile;
   try {
-    profile = await repo.getOne(user?.userId);
+    const profile = await repo.getOne(user?.userId);
+    return {
+      profile,
+    };
   } catch (e) {
     if (e instanceof APIError) {
       return fail(401, { message: e.detail });
@@ -20,8 +22,4 @@ export const load: PageServerLoad = async ({ locals }) => {
     console.error(e);
     throw error(500, { message: SERVER_ERROR });
   }
-
-  return {
-    profile,
-  };
 };

--- a/src/routes/project/[id]/+page.server.ts
+++ b/src/routes/project/[id]/+page.server.ts
@@ -14,7 +14,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
   const { user } = await locals.auth.validateUser();
   const repo = new ProjectRepo(prisma);
   try {
-    const project = await repo.getOne(params.id, user?.userId);
+    const project = await repo.getOneAndValidateOwner(params.id, user?.userId);
     // NOTE: we should create some sort of helper function for fetching batches of s3 object urls
     // once it is used more often that returns an object of this signature.
     const s3ObjectUrls: { [key: string]: string } = {};
@@ -110,7 +110,7 @@ export const actions: Actions = {
 
     const repo = new ProjectRepo(prisma);
     try {
-      const project = await repo.getOne(id, user?.userId);
+      const project = await repo.getOneAndValidateOwner(id, user?.userId);
 
       const file = formData.get('file');
       if (file instanceof File) {

--- a/src/routes/trainingProgram/[id]/+page.server.ts
+++ b/src/routes/trainingProgram/[id]/+page.server.ts
@@ -13,7 +13,8 @@ export const load: PageServerLoad = async ({ locals, params }) => {
 
   try {
     const trainingProgramRepo = new TrainingProgramRepo(prisma);
-    const trainingProgram = await trainingProgramRepo.getOne(Number(params.id), user?.userId);
+    const trainingProgram = await trainingProgramRepo.getOne(Number(params.id));
+    // If no user is signed in and the training program is not public, error out
     if (!trainingProgram.isPublic && !user) {
       throw error(403, 'Unauthorized');
     }

--- a/src/routes/trainingProgram/[id]/edit/+page.server.ts
+++ b/src/routes/trainingProgram/[id]/edit/+page.server.ts
@@ -17,7 +17,10 @@ export const load: PageServerLoad = async ({ locals, params, url }) => {
   try {
     const trainingProgramRepo = new TrainingProgramRepo(prisma);
     const exerciseRepo = new ExerciseRepo(prisma);
-    const trainingProgram = await trainingProgramRepo.getOne(Number(id), user?.userId);
+    const trainingProgram = await trainingProgramRepo.getOneAndValidateOwner(
+      Number(id),
+      user?.userId
+    );
     const exercises = await exerciseRepo.get({
       _count: {
         select: {

--- a/src/routes/widget/+page.server.ts
+++ b/src/routes/widget/+page.server.ts
@@ -19,7 +19,36 @@ export const load: PageServerLoad = async ({ locals, url }) => {
 
   let widgets;
   try {
-    widgets = await widgetRepo.get({ isTemplate: true }, { useCount: 'desc' });
+    widgets = await widgetRepo.get({
+      where: {
+        // Show published widgets, or just user's widgets
+        OR: [
+          {
+            isTemplate: true,
+            ownerId: user.userId,
+          },
+          {
+            isTemplate: true,
+            isPublished: true,
+          },
+        ],
+      },
+      include: {
+        owner: true,
+        datasets: {
+          include: {
+            customQueries: {
+              include: {
+                conditions: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        useCount: 'desc',
+      },
+    });
     // compile datasets for widgets
     const customQueryResults: CustomQueryResults[] = [];
     for (const w of widgets) {

--- a/src/routes/widget/+page.server.ts
+++ b/src/routes/widget/+page.server.ts
@@ -17,36 +17,17 @@ export const load: PageServerLoad = async ({ locals, url }) => {
   const widgetRepo = new WidgetRepo(prisma);
   const customQueryRepo = new CustomQueryRepo(prisma);
 
-  let widgets;
   try {
-    widgets = await widgetRepo.get({
-      where: {
-        // Show published widgets, or just user's widgets
-        OR: [
-          {
-            isTemplate: true,
-            ownerId: user.userId,
-          },
-          {
-            isTemplate: true,
-            isPublished: true,
-          },
-        ],
-      },
-      include: {
-        owner: true,
-        datasets: {
-          include: {
-            customQueries: {
-              include: {
-                conditions: true,
-              },
+    const widgets = await widgetRepo.getAllPublishedOrOwnedTemplates(user.userId, {
+      owner: true,
+      datasets: {
+        include: {
+          customQueries: {
+            include: {
+              conditions: true,
             },
           },
         },
-      },
-      orderBy: {
-        useCount: 'desc',
       },
     });
     // compile datasets for widgets


### PR DESCRIPTION
- `getOne` for all business logic files no longer check authentication
- All auth checks are done in `getOneAndValidateUser`
- Include is passable through widget calls as a POC for optimizing load calls
  - Also removed the ability to pass the filters in the get call as that logic should exist in `widget.ts`