### PR TITLE
Fix calendar widget bugs

### DIFF
--- a/src/lib/api/trainingProgramActivations.ts
+++ b/src/lib/api/trainingProgramActivations.ts
@@ -1,10 +1,10 @@
 import { useQuery } from '@sveltestack/svelte-query';
 
-export function getTrainingProgramActivations(startStr: string, endStr: string) {
+export function getTrainingProgramActivations() {
   const fetchData = async () => {
-    const data = await fetch(`/api/trainingProgramActivations?start=${startStr}&end=${endStr}`);
+    const data = await fetch(`/api/trainingProgramActivations`);
     return data.json();
   };
 
-  return useQuery(['trainingProgramActivations', { startStr, endStr }], () => fetchData());
+  return useQuery(['trainingProgramActivations'], () => fetchData());
 }

--- a/src/lib/components/Calendar.svelte
+++ b/src/lib/components/Calendar.svelte
@@ -134,21 +134,12 @@
       const { trainingProgramScheduledSlots } = a.trainingProgram;
       // Again we use UTC here because there is no time involved in these
       // data structures
-      let startDate = dayjs.tz(a.startDate, 'UTC');
-      trainingProgramScheduledSlots.forEach((s, i) => {
+      let startDate = dayjs.utc(a.startDate);
+      trainingProgramScheduledSlots.forEach((s) => {
         const endDate = startDate.add(s.duration, 'weeks');
         events.push({
-          start: startDate.startOf('day').toDate().toISOString().split('T', 1)[0],
-          // Subtract one day from the end date if it is not the last one so there
-          // is no overlap in the calendar view
-          end: (i != trainingProgramScheduledSlots.length - 1
-            ? endDate.subtract(1, 'day')
-            : endDate
-          )
-            .startOf('day')
-            .toDate()
-            .toISOString()
-            .split('T', 1)[0],
+          start: startDate.toISOString().split('T', 1)[0],
+          end: endDate.toISOString().split('T', 1)[0],
           backgroundColor: '#8bfca9',
           allDay: true,
           title: `${a.trainingProgram.name} - ${s.trainingCycles[0].name} `,

--- a/src/lib/components/Calendar.svelte
+++ b/src/lib/components/Calendar.svelte
@@ -53,7 +53,8 @@
       // we use the raw UTC here because we are blocking out DAYS and we want
       // no interference from time
       start: e.dateStart.split('T', 1)[0],
-      end: e.dateEnd.split('T', 1)[0],
+      // Value is exclusive so we need to add a day
+      end: dayjs.utc(e.dateEnd).add(1, 'day').toISOString().split('T', 1)[0],
       backgroundColor: e.color,
       allDay: true,
       title: e.title,

--- a/src/lib/components/Calendar.svelte
+++ b/src/lib/components/Calendar.svelte
@@ -187,8 +187,7 @@
   $: calendarEventsQuery = startStr && endStr ? getCalendarEvents(startStr, endStr) : undefined;
   $: journalEntriesQuery = startStr && endStr ? getJournalEntries(startStr, endStr) : undefined;
   $: exerciseEventsQuery = startStr && endStr ? getExerciseEvents(startStr, endStr) : undefined;
-  $: trainingProgramActivationsQuery =
-    startStr && endStr ? getTrainingProgramActivations(startStr, endStr) : undefined;
+  $: trainingProgramActivationsQuery = getTrainingProgramActivations();
 
   // Construct events using the reactive data from each of the queries defined above
   let events: Event[] = [];

--- a/src/lib/server/repos/trainingProgram.ts
+++ b/src/lib/server/repos/trainingProgram.ts
@@ -565,7 +565,10 @@ export class TrainingProgramRepo implements Repo<TrainingProgram, Prisma.Trainin
         ownerId,
         ...where,
       },
-      include: {
+      select: {
+        id: true,
+        startDate: true,
+        trainingProgramId: true,
         trainingProgram: {
           select: {
             name: true,

--- a/src/routes/api/trainingProgramActivations/+server.ts
+++ b/src/routes/api/trainingProgramActivations/+server.ts
@@ -24,7 +24,7 @@ export type APITrainingProgramActivationsResponse = (Prisma.TrainingProgramActiv
   };
 }> & { startDate: string; endDate: string })[];
 
-export const GET: RequestHandler = async ({ url, locals }) => {
+export const GET: RequestHandler = async ({ locals }) => {
   const session = await locals.auth.validate();
   if (session === null) {
     throw error(403);
@@ -33,31 +33,10 @@ export const GET: RequestHandler = async ({ url, locals }) => {
   const user = session.user;
   const trainingProgramRepo = new TrainingProgramRepo(prisma);
 
-  const start = url.searchParams.get('start');
-  const end = url.searchParams.get('end');
-
-  if (start == null) {
-    throw error(401, 'Must specify start date');
-  }
-  if (end == null) {
-    throw error(401, 'Must specify end date');
-  }
-
-  // Workaround for time zone adjustmants made by date... and the fact that
-  // date coming from calendar is not full iso string... lame
-  const startDate = new Date(start);
-  startDate.setUTCHours(0, 0, 0, 0);
-  const endDate = new Date(end);
-  endDate.setUTCHours(0, 0, 0, 0);
-
+  // TODO: Calculating the end date for an activation takes some computation and is more
+  // complex than a trivial query. For now we will fetch all activations.
   const trainingProgramActivations = await trainingProgramRepo.getActivations({
     ownerId: user?.userId,
-    where: {
-      startDate: {
-        gte: startDate,
-        lte: endDate,
-      },
-    },
   });
 
   return json(trainingProgramActivations);

--- a/src/routes/trainingProgram/+page.server.ts
+++ b/src/routes/trainingProgram/+page.server.ts
@@ -84,7 +84,7 @@ export const actions: Actions = {
       return fail(400, { form });
     }
 
-    if (dayjs(form.data.startDate).day() > 1) {
+    if (dayjs.utc(form.data.startDate).day() > 1) {
       return setError(form, 'startDate', 'Start Date must be on a Monday or Sunday');
     }
 

--- a/src/routes/trainingProgram/[id]/activation/[activationId]/+page.server.ts
+++ b/src/routes/trainingProgram/[id]/activation/[activationId]/+page.server.ts
@@ -45,7 +45,7 @@ export const actions: Actions = {
       return fail(400, { form });
     }
 
-    if (dayjs(form.data.startDate).day() > 1) {
+    if (dayjs.utc(form.data.startDate).day() > 1) {
       return setError(
         form,
         'startDate',


### PR DESCRIPTION
- Training program activation no longer attempts to query within a date range. I forgot there is some computation required to get the end date so for now we will stick with getting them all
- Calendar is using `dayjs.utc` format 
- No longer subtracting a day from the end of middle activation cycles. Now that we are using UTC the exclusivity works correctly
- Fixed bug where you couldn't schedule on a Monday because we weren't using UTC for that check